### PR TITLE
Use adventure components instead of legacy strings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 8
+        java-version: 17
 
     - name: Cache maven packages to speed up build
       uses: actions/cache@v1

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
+            <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <version>master</version>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.test.skip>true</maven.test.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/src/main/java/pw/kaboom/weapons/commands/CommandWeapons.java
+++ b/src/main/java/pw/kaboom/weapons/commands/CommandWeapons.java
@@ -10,13 +10,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
 
 public final class CommandWeapons implements CommandExecutor {
-    private void addWeapon(final Inventory inventory, final Material material, final String name) {
+    private void addWeapon(final Inventory inventory, final Material material,
+                                         final Component name) {
         final ItemStack item = new ItemStack(material, 1);
         final ItemMeta itemMeta = item.getItemMeta();
 
-        itemMeta.setDisplayName(name);
+        itemMeta.displayName(name);
         item.setItemMeta(itemMeta);
         inventory.addItem(item);
     }
@@ -25,21 +27,21 @@ public final class CommandWeapons implements CommandExecutor {
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label,
                              final String[] args) {
         if (sender instanceof ConsoleCommandSender) {
-            sender.sendMessage("Command has to be run by a player");
+            sender.sendMessage(Component.text("Command has to be run by a player"));
         } else {
             final Player player = (Player) sender;
-            final Inventory inventory = Bukkit.createInventory(null, 18, "Weapons");
+            final Inventory inventory = Bukkit.createInventory(null, 18, Component.text("Weapons"));
 
-            addWeapon(inventory, Material.ANVIL, "§rAnvil Dropper");
-            addWeapon(inventory, Material.SPECTRAL_ARROW, "§rArcher");
-            addWeapon(inventory, Material.FIRE_CHARGE, "§rArmageddon");
-            addWeapon(inventory, Material.MAGMA_CREAM, "§rBlobinator");
-            addWeapon(inventory, Material.EGG, "§rGrenade");
-            addWeapon(inventory, Material.BLAZE_POWDER, "§rLaser");
-            addWeapon(inventory, Material.STICK, "§rLightning Stick");
-            addWeapon(inventory, Material.GOLDEN_HORSE_ARMOR, "§rMachine Gun");
-            addWeapon(inventory, Material.BLAZE_ROD, "§rNuker");
-            addWeapon(inventory, Material.IRON_HORSE_ARMOR, "§rSniper");
+            addWeapon(inventory, Material.ANVIL, Component.text("Anvil Dropper"));
+            addWeapon(inventory, Material.SPECTRAL_ARROW, Component.text("Archer"));
+            addWeapon(inventory, Material.FIRE_CHARGE, Component.text("Armageddon"));
+            addWeapon(inventory, Material.MAGMA_CREAM, Component.text("Blobinator"));
+            addWeapon(inventory, Material.EGG, Component.text("Grenade"));
+            addWeapon(inventory, Material.BLAZE_POWDER, Component.text("Laser"));
+            addWeapon(inventory, Material.STICK, Component.text("Lightning Stick"));
+            addWeapon(inventory, Material.GOLDEN_HORSE_ARMOR, Component.text("Machine Gun"));
+            addWeapon(inventory, Material.BLAZE_ROD, Component.text("Nuker"));
+            addWeapon(inventory, Material.IRON_HORSE_ARMOR, Component.text("Sniper"));
             player.openInventory(inventory);
         }
         return true;

--- a/src/main/java/pw/kaboom/weapons/commands/CommandWeapons.java
+++ b/src/main/java/pw/kaboom/weapons/commands/CommandWeapons.java
@@ -10,7 +10,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class CommandWeapons implements CommandExecutor {
     private void addWeapon(final Inventory inventory, final Material material,
@@ -32,16 +34,26 @@ public final class CommandWeapons implements CommandExecutor {
             final Player player = (Player) sender;
             final Inventory inventory = Bukkit.createInventory(null, 18, Component.text("Weapons"));
 
-            addWeapon(inventory, Material.ANVIL, Component.text("Anvil Dropper"));
-            addWeapon(inventory, Material.SPECTRAL_ARROW, Component.text("Archer"));
-            addWeapon(inventory, Material.FIRE_CHARGE, Component.text("Armageddon"));
-            addWeapon(inventory, Material.MAGMA_CREAM, Component.text("Blobinator"));
-            addWeapon(inventory, Material.EGG, Component.text("Grenade"));
-            addWeapon(inventory, Material.BLAZE_POWDER, Component.text("Laser"));
-            addWeapon(inventory, Material.STICK, Component.text("Lightning Stick"));
-            addWeapon(inventory, Material.GOLDEN_HORSE_ARMOR, Component.text("Machine Gun"));
-            addWeapon(inventory, Material.BLAZE_ROD, Component.text("Nuker"));
-            addWeapon(inventory, Material.IRON_HORSE_ARMOR, Component.text("Sniper"));
+            addWeapon(inventory, Material.ANVIL, Component.text("Anvil Dropper")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.SPECTRAL_ARROW, Component.text("Archer")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.FIRE_CHARGE, Component.text("Armageddon")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.MAGMA_CREAM, Component.text("Blobinator")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.EGG, Component.text("Grenade")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.BLAZE_POWDER, Component.text("Laser")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.STICK, Component.text("Lightning Stick")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.GOLDEN_HORSE_ARMOR, Component.text("Machine Gun")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.BLAZE_ROD, Component.text("Nuker")
+                    .decoration(TextDecoration.ITALIC, false));
+            addWeapon(inventory, Material.IRON_HORSE_ARMOR, Component.text("Sniper")
+                    .decoration(TextDecoration.ITALIC, false));
             player.openInventory(inventory);
         }
         return true;

--- a/src/main/java/pw/kaboom/weapons/modules/player/PlayerReceiveWeapon.java
+++ b/src/main/java/pw/kaboom/weapons/modules/player/PlayerReceiveWeapon.java
@@ -6,20 +6,26 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
+import net.kyori.adventure.text.Component;
+
 public final class PlayerReceiveWeapon implements Listener {
     @EventHandler
     void onInventoryClick(final InventoryClickEvent event) {
-        if (event.isCancelled() || !"Weapons".equals(event.getView().getTitle())) {
+        if (event.isCancelled() || !Component.text("Weapons").equals(event.getView().title())) {
             return;
         }
 
         final ItemStack item = event.getCurrentItem();
-        final String weaponName = item.getItemMeta().getDisplayName().toLowerCase();
+        final Component weaponName = item.getItemMeta().displayName();
         final Player player = (Player) event.getWhoClicked();
 
         player.getInventory().addItem(item);
         player.closeInventory();
-        player.sendMessage("You have received the " + weaponName + "!");
+        player.sendMessage(
+            Component.text("You have received the ")
+                .append(weaponName)
+                .append(Component.text("!"))
+        );
     }
 }
 

--- a/src/main/java/pw/kaboom/weapons/modules/player/PlayerUseWeapon.java
+++ b/src/main/java/pw/kaboom/weapons/modules/player/PlayerUseWeapon.java
@@ -7,6 +7,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+import net.kyori.adventure.text.Component;
+
 import pw.kaboom.weapons.modules.weapons.WeaponAnvilDropper;
 import pw.kaboom.weapons.modules.weapons.WeaponArcher;
 import pw.kaboom.weapons.modules.weapons.WeaponArmageddon;
@@ -26,10 +28,10 @@ public final class PlayerUseWeapon implements Listener {
             return;
         }
 
-        String name = "";
+        Component name = Component.empty();
 
         try {
-            name = event.getItem().getItemMeta().getDisplayName();
+            name = event.getItem().getItemMeta().displayName();
         } catch (Exception ignored) {
             return;
         }

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponAnvilDropper.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponAnvilDropper.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponAnvilDropper {
     private WeaponAnvilDropper() {
@@ -13,7 +14,8 @@ public final class WeaponAnvilDropper {
 
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.ANVIL && Component.text("Anvil Dropper").equals(name)) {
+        if (item == Material.ANVIL && Component.text("Anvil Dropper")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final int min = -2;
             final int max = 2;
 

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponAnvilDropper.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponAnvilDropper.java
@@ -5,14 +5,15 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponAnvilDropper {
     private WeaponAnvilDropper() {
     }
 
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.ANVIL
-                && ("§rAnvil Dropper".equals(name) || "Anvil Dropper".equals(name))) {
+        if (item == Material.ANVIL && Component.text("Anvil Dropper").equals(name)) {
             final int min = -2;
             final int max = 2;
 

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArcher.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArcher.java
@@ -16,11 +16,12 @@ import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponArcher implements Listener {
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.SPECTRAL_ARROW
-                && ("§rArcher".equals(name) || "Archer".equals(name))) {
+        if (item == Material.SPECTRAL_ARROW && Component.text("Archer").equals(name)) {
             final Player player = event.getPlayer();
             final World world = player.getWorld();
 
@@ -40,7 +41,7 @@ public final class WeaponArcher implements Listener {
                     player.getLocation(),
                     EntityType.SPECTRAL_ARROW
                 );
-                arrow.setCustomName("WeaponArcherArrow");
+                arrow.customName(Component.text("WeaponArcherArrow"));
                 arrow.setShooter(player);
                 arrow.setVelocity(randomDirection);
             }
@@ -65,7 +66,7 @@ public final class WeaponArcher implements Listener {
         if (event.getEntityType() == EntityType.SPECTRAL_ARROW) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponArcherArrow".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponArcherArrow").equals(projectile.customName())) {
                 final Entity collidedWith = event.getCollidedWith();
 
                 if (collidedWith.getType() == EntityType.PLAYER

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArcher.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArcher.java
@@ -17,11 +17,13 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponArcher implements Listener {
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.SPECTRAL_ARROW && Component.text("Archer").equals(name)) {
+        if (item == Material.SPECTRAL_ARROW && Component.text("Archer")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final World world = player.getWorld();
 

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArmageddon.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArmageddon.java
@@ -16,11 +16,12 @@ import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponArmageddon implements Listener {
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.FIRE_CHARGE
-                && ("§rArmageddon".equals(name) || "Armageddon".equals(name))) {
+        if (item == Material.FIRE_CHARGE && Component.text("Armageddon").equals(name)) {
             final Player player = event.getPlayer();
             final World world = player.getWorld();
 
@@ -43,7 +44,7 @@ public final class WeaponArmageddon implements Listener {
                 );
 
                 fireball.setBounce(false);
-                fireball.setCustomName("WeaponArmegaddonCharge");
+                fireball.customName(Component.text("WeaponArmegaddonCharge"));
                 fireball.setDirection(velocity);
                 fireball.setShooter(player);
                 fireball.setYield(yield);
@@ -70,7 +71,7 @@ public final class WeaponArmageddon implements Listener {
         if (event.getEntityType() == EntityType.FIREBALL) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponArmegaddonCharge".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponArmegaddonCharge").equals(projectile.customName())) {
                 final Entity collidedWith = event.getCollidedWith();
 
                 if ((collidedWith.getType() == EntityType.PLAYER

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArmageddon.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponArmageddon.java
@@ -17,11 +17,13 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponArmageddon implements Listener {
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.FIRE_CHARGE && Component.text("Armageddon").equals(name)) {
+        if (item == Material.FIRE_CHARGE && Component.text("Armageddon")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final World world = player.getWorld();
 

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponBlobinator.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponBlobinator.java
@@ -21,13 +21,15 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 import pw.kaboom.weapons.Main;
 
 public final class WeaponBlobinator implements Listener {
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.MAGMA_CREAM && Component.text("Blobinator").equals(name)) {
+        if (item == Material.MAGMA_CREAM && Component.text("Blobinator")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(8);

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponBlobinator.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponBlobinator.java
@@ -20,19 +20,20 @@ import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
+import net.kyori.adventure.text.Component;
+
 import pw.kaboom.weapons.Main;
 
 public final class WeaponBlobinator implements Listener {
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.MAGMA_CREAM
-                && ("§rBlobinator".equals(name) || "Blobinator".equals(name))) {
+        if (item == Material.MAGMA_CREAM && Component.text("Blobinator").equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(8);
 
             final Snowball snowball = player.launchProjectile(Snowball.class);
-            snowball.setCustomName("WeaponBlobinatorBall");
+            snowball.customName(Component.text("WeaponBlobinatorBall"));
             snowball.setShooter(player);
             snowball.setVelocity(velocity);
 
@@ -74,7 +75,7 @@ public final class WeaponBlobinator implements Listener {
         if (event.getEntityType() == EntityType.SNOWBALL) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponBlobinatorBall".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponBlobinatorBall").equals(projectile.customName())) {
                 event.setCancelled(true);
             }
         }
@@ -87,7 +88,7 @@ public final class WeaponBlobinator implements Listener {
             final Projectile projectile = event.getEntity();
 
             if (hitBlock != null
-                    && "WeaponBlobinatorBall".equals(projectile.getCustomName())) {
+                    && Component.text("WeaponBlobinatorBall").equals(projectile.customName())) {
                 final int radius = 4;
                 final World world = projectile.getWorld();
                 final Material color = Main.getColors().get(

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponGrenade.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponGrenade.java
@@ -15,11 +15,13 @@ import org.bukkit.event.player.PlayerEggThrowEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponGrenade implements Listener {
     public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.EGG && Component.text("Grenade").equals(name)) {
+        if (item == Material.EGG && Component.text("Grenade")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             event.setCancelled(true);
 
             final Player player = event.getPlayer();

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponGrenade.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponGrenade.java
@@ -14,18 +14,19 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerEggThrowEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponGrenade implements Listener {
-    public static void rightClick(final Material item, final String name,
+    public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.EGG
-                && ("§rGrenade".equals(name) || "Grenade".equals(name))) {
+        if (item == Material.EGG && Component.text("Grenade").equals(name)) {
             event.setCancelled(true);
 
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
 
             final Egg egg = player.launchProjectile(Egg.class);
-            egg.setCustomName("WeaponGrenade");
+            egg.customName(Component.text("WeaponGrenade"));
             egg.setShooter(player);
 
             final World world = player.getWorld();
@@ -43,7 +44,7 @@ public final class WeaponGrenade implements Listener {
 
     @EventHandler
     private void onPlayerEggThrow(final PlayerEggThrowEvent event) {
-        if ("WeaponGrenade".equals(event.getEgg().getCustomName())) {
+        if (Component.text("WeaponGrenade").equals(event.getEgg().customName())) {
             event.setHatching(false);
         }
     }
@@ -53,7 +54,7 @@ public final class WeaponGrenade implements Listener {
         if (event.getEntityType() == EntityType.EGG) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponGrenade".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponGrenade").equals(projectile.customName())) {
                 final Location location = projectile.getLocation();
                 final World world = location.getWorld();
                 final float power = 6;

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLaser.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLaser.java
@@ -13,14 +13,15 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponLaser {
     private WeaponLaser() {
     }
 
-    public static void rightClick(final Material item, final String name,
+    public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.BLAZE_POWDER
-                && ("§rLaser".equals(name) || "Laser".equals(name))) {
+        if (item == Material.BLAZE_POWDER && Component.text("Laser").equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector direction = eyeLocation.getDirection();

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLaser.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLaser.java
@@ -14,6 +14,7 @@ import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponLaser {
     private WeaponLaser() {
@@ -21,7 +22,8 @@ public final class WeaponLaser {
 
     public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.BLAZE_POWDER && Component.text("Laser").equals(name)) {
+        if (item == Material.BLAZE_POWDER && Component.text("Laser")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector direction = eyeLocation.getDirection();

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLightningStick.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLightningStick.java
@@ -8,6 +8,7 @@ import org.bukkit.World;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponLightningStick {
     private WeaponLightningStick() {
@@ -15,7 +16,8 @@ public final class WeaponLightningStick {
 
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.STICK && Component.text("Lightning Stick").equals(name)) {
+        if (item == Material.STICK && Component.text("Lightning Stick")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final int maxDistance = 100;
             final Location lookLocation = event.getPlayer().getTargetBlock(
                 (Set<Material>) null, maxDistance).getLocation();

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLightningStick.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponLightningStick.java
@@ -7,14 +7,15 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.event.player.PlayerInteractEvent;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponLightningStick {
     private WeaponLightningStick() {
     }
 
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.STICK
-                && ("§rLightning Stick".equals(name) || "Lightning Stick".equals(name))) {
+        if (item == Material.STICK && Component.text("Lightning Stick").equals(name)) {
             final int maxDistance = 100;
             final Location lookLocation = event.getPlayer().getTargetBlock(
                 (Set<Material>) null, maxDistance).getLocation();

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponMachineGun.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponMachineGun.java
@@ -26,6 +26,7 @@ import org.bukkit.util.Vector;
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 import pw.kaboom.weapons.Main;
 
@@ -34,7 +35,8 @@ public final class WeaponMachineGun implements Listener {
 
     public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.GOLDEN_HORSE_ARMOR && Component.text("Machine Gun").equals(name)) {
+        if (item == Material.GOLDEN_HORSE_ARMOR && Component.text("Machine Gun")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final UUID playerUUID = event.getPlayer().getUniqueId();
 
             if (!machineGunActive.contains(playerUUID)) {

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponMachineGun.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponMachineGun.java
@@ -25,15 +25,16 @@ import org.bukkit.util.Vector;
 
 import com.destroystokyo.paper.event.entity.ProjectileCollideEvent;
 
+import net.kyori.adventure.text.Component;
+
 import pw.kaboom.weapons.Main;
 
 public final class WeaponMachineGun implements Listener {
     private static HashSet<UUID> machineGunActive = new HashSet<UUID>();
 
-    public static void rightClick(final Material item, final String name,
+    public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.GOLDEN_HORSE_ARMOR
-                && ("§rMachine Gun".equals(name) || "Machine Gun".equals(name))) {
+        if (item == Material.GOLDEN_HORSE_ARMOR && Component.text("Machine Gun").equals(name)) {
             final UUID playerUUID = event.getPlayer().getUniqueId();
 
             if (!machineGunActive.contains(playerUUID)) {
@@ -52,7 +53,7 @@ public final class WeaponMachineGun implements Listener {
 
                         final Arrow arrow = player.launchProjectile(Arrow.class);
 
-                        arrow.setCustomName("WeaponMachineGunBullet");
+                        arrow.customName(Component.text("WeaponMachineGunBullet"));
                         arrow.setShooter(player);
                         arrow.setVelocity(velocity);
 
@@ -86,7 +87,7 @@ public final class WeaponMachineGun implements Listener {
         if (event.getEntityType() == EntityType.ARROW) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponMachineGunBullet".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponMachineGunBullet").equals(projectile.customName())) {
                 final Entity collidedWith = event.getCollidedWith();
 
                 if (collidedWith.getType() == EntityType.PLAYER
@@ -119,7 +120,7 @@ public final class WeaponMachineGun implements Listener {
         if (event.getEntityType() == EntityType.ARROW) {
             final Projectile projectile = event.getEntity();
 
-            if ("WeaponMachineGunBullet".equals(projectile.getCustomName())) {
+            if (Component.text("WeaponMachineGunBullet").equals(projectile.customName())) {
                 projectile.remove();
             }
         }

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponNuker.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponNuker.java
@@ -9,14 +9,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.Vector;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponNuker {
     private WeaponNuker() {
     }
 
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.BLAZE_ROD
-                && ("§rNuker".equals(name) || "Nuker".equals(name))) {
+        if (item == Material.BLAZE_ROD && Component.text("Nuker").equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(10);

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponNuker.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponNuker.java
@@ -10,6 +10,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.util.Vector;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponNuker {
     private WeaponNuker() {
@@ -17,7 +18,8 @@ public final class WeaponNuker {
 
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.BLAZE_ROD && Component.text("Nuker").equals(name)) {
+        if (item == Material.BLAZE_ROD && Component.text("Nuker")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(10);

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponSniper.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponSniper.java
@@ -11,14 +11,15 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
+import net.kyori.adventure.text.Component;
+
 public final class WeaponSniper {
     private WeaponSniper() {
     }
 
-    public static void leftClick(final Material item, final String name,
+    public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.IRON_HORSE_ARMOR
-                && ("§rSniper".equals(name) || "Sniper".equals(name))) {
+        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper").equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(12);
@@ -41,10 +42,9 @@ public final class WeaponSniper {
         }
     }
 
-    public static void rightClick(final Material item, final String name,
+    public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.IRON_HORSE_ARMOR
-                && ("§rSniper".equals(name) || "Sniper".equals(name))) {
+        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper").equals(name)) {
             final Player player = event.getPlayer();
 
             if (player.hasPotionEffect(PotionEffectType.SLOW)) {

--- a/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponSniper.java
+++ b/src/main/java/pw/kaboom/weapons/modules/weapons/WeaponSniper.java
@@ -12,6 +12,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class WeaponSniper {
     private WeaponSniper() {
@@ -19,7 +20,8 @@ public final class WeaponSniper {
 
     public static void leftClick(final Material item, final Component name,
                                  final PlayerInteractEvent event) {
-        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper").equals(name)) {
+        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
             final Location eyeLocation = player.getEyeLocation();
             final Vector velocity = eyeLocation.getDirection().multiply(12);
@@ -44,7 +46,8 @@ public final class WeaponSniper {
 
     public static void rightClick(final Material item, final Component name,
                                   final PlayerInteractEvent event) {
-        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper").equals(name)) {
+        if (item == Material.IRON_HORSE_ARMOR && Component.text("Sniper")
+                .decoration(TextDecoration.ITALIC, false).equals(name)) {
             final Player player = event.getPlayer();
 
             if (player.hasPotionEffect(PotionEffectType.SLOW)) {


### PR DESCRIPTION
This PR replaces legacy message strings with adventure components. This makes the components cleaner, including in the item data.

Here is the data of a weapon (obtained with a `data` command) before the change:
![data](https://user-images.githubusercontent.com/65827213/199390936-05e98a2a-0e9c-42f3-9ae8-e5f34d24a932.png)

And here is the data after the change:
![data](https://user-images.githubusercontent.com/65827213/199390905-03c2de59-3e81-42ee-8cbe-9b7d7f02de3a.png)

Also, the items' names now appear italic client-side, but I can try to fix that if you want.