### PR TITLE
Opt out of remapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,19 @@
 
     <build>
         <finalName>${project.artifactId}</finalName>
-        <plugins>
+	<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <paperweight-mappings-namespace>mojang</paperweight-mappings-namespace>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
Unfortunately, Paper 1.20.6+ servers assume that a plugin needs remapping by default - so, as Amy notes in [one of the commits in her CommandSpy PR](https://github.com/kaboomserver/commandspy/pull/11/commits/1ca2ffc91aea7c593f32d771ba754cfb0fbbfc43) the server would waste time on first start remapping classes that don't need remapping.